### PR TITLE
Increase file upload size and add proxy network creation step

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -38,6 +38,9 @@ jobs:
           cd deploy
           docker compose -f docker-compose.prod.yml config
 
+      - name: Create proxy network
+        run: docker network create proxy
+
       - name: Build all services
         run: |
           cd deploy

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -84,8 +84,8 @@ func (s *Server) ListGalleryItems(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) CreateGalleryItem(w http.ResponseWriter, r *http.Request) {
-    // Parse multipart form with max 10MB
-    if err := r.ParseMultipartForm(10 << 20); err != nil {
+    // Parse multipart form with max 500MB
+    if err := r.ParseMultipartForm(500 << 20); err != nil {
         http.Error(w, "bad request", http.StatusBadRequest)
         return
     }

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -6,6 +6,9 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # Allow larger file uploads (500MB)
+  client_max_body_size 500M;
+
   # Serve API by proxying to the app service
   location /api/ {
     proxy_pass http://app:8080/api/;


### PR DESCRIPTION
Increase the maximum file upload size to 500MB in both the application and Nginx configuration. Add a step to create a proxy network in the test deployment workflow.