### PR TITLE
Add database migration support with initial schema

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.0.0
+	github.com/golang-migrate/migrate/v4 v4.17.0
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.7
 	github.com/minio/minio-go/v7 v7.0.63

--- a/app/main.go
+++ b/app/main.go
@@ -7,11 +7,35 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
+
+func runMigrations(db *sql.DB) error {
+	driver, err := postgres.WithInstance(db, &postgres.Config{})
+	if err != nil {
+		return err
+	}
+
+	m, err := migrate.NewWithDatabaseInstance(
+		"file:///app/migrations",
+		"postgres", driver)
+	if err != nil {
+		return err
+	}
+
+	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+		return err
+	}
+
+	log.Println("Database migrations completed successfully")
+	return nil
+}
 
 func main() {
     dsn := os.Getenv("DATABASE_URL")
@@ -30,6 +54,11 @@ func main() {
         log.Fatalf("db open: %v", err)
     }
     defer db.Close()
+
+	// Run database migrations
+	if err := runMigrations(db); err != nil {
+		log.Fatalf("failed to run migrations: %v", err)
+	}
 
     // Initialize MinIO client
     endpoint := os.Getenv("MINIO_ENDPOINT")

--- a/db/migrations/001_initial_schema.down.sql
+++ b/db/migrations/001_initial_schema.down.sql
@@ -1,0 +1,4 @@
+-- Rollback initial schema
+DROP TABLE IF EXISTS site_settings;
+DROP TABLE IF EXISTS gallery_items;
+DROP TABLE IF EXISTS admin_users;

--- a/db/migrations/001_initial_schema.up.sql
+++ b/db/migrations/001_initial_schema.up.sql
@@ -1,0 +1,29 @@
+-- Initial schema migration
+CREATE TABLE IF NOT EXISTS admin_users (
+  id SERIAL PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS gallery_items (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  info TEXT,
+  year_created INTEGER,
+  description TEXT,
+  image_path TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS site_settings (
+  id INTEGER PRIMARY KEY DEFAULT 1,
+  hero_image_id INTEGER,
+  about_image_id INTEGER,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  CONSTRAINT single_row CHECK (id = 1)
+);
+
+-- Seed admin (username: admin, password: password)
+INSERT INTO admin_users (username, password)
+VALUES ('admin', 'password')
+ON CONFLICT (username) DO NOTHING;

--- a/db/migrations/002_remove_story.down.sql
+++ b/db/migrations/002_remove_story.down.sql
@@ -1,0 +1,2 @@
+-- Add story column back (rollback)
+ALTER TABLE gallery_items ADD COLUMN IF NOT EXISTS story TEXT;

--- a/db/migrations/002_remove_story.up.sql
+++ b/db/migrations/002_remove_story.up.sql
@@ -1,0 +1,2 @@
+-- Remove story column from gallery_items if it exists
+ALTER TABLE gallery_items DROP COLUMN IF EXISTS story;

--- a/deploy/Dockerfile.app
+++ b/deploy/Dockerfile.app
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY go.mod go.sum* ./
 RUN if [ -f go.mod ]; then go mod download; fi
 COPY . .
+COPY ../db/migrations /app/migrations
 
 # Add an entrypoint that ensures modules are downloaded inside the container at start
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
@@ -24,5 +25,6 @@ RUN go build -o /app/server ./
 # Production stage
 FROM alpine:3.18 AS production
 COPY --from=build /app/server /server
+COPY --from=build /src/../db/migrations /app/migrations
 EXPOSE 8080
 ENTRYPOINT ["/server"]

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -30,6 +30,8 @@ services:
       target: development
     ports:
       - "8080:8080"
+    volumes:
+      - ../db/migrations:/app/migrations:ro
     restart: unless-stopped
     
 


### PR DESCRIPTION
Introduce support for database migrations and include an initial schema along with rollback scripts for `gallery_items` and `site_settings`. This enhancement streamlines database management and ensures easier updates.