### PR TITLE
Replace ports with expose for web service in docker-compose.prod.yml

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -45,8 +45,8 @@ services:
         VITE_CONTACT_EMAIL: ${VITE_CONTACT_EMAIL:-hello@example.com}
         VITE_INSTAGRAM_URL: ${VITE_INSTAGRAM_URL:-#}
         VITE_TWITTER_URL: ${VITE_TWITTER_URL:-#}
-    ports:
-      - "80:80"
+    expose:
+      - 80
     networks:
       - default
       - proxy


### PR DESCRIPTION
Update the Docker Compose configuration to use `expose` instead of `ports` for the web service, enhancing security by not publishing the port to the host.