### PR TITLE
Add migration scripts for fresh deployments

### DIFF
--- a/db/migrations/003_clear_orphaned_images.down.sql
+++ b/db/migrations/003_clear_orphaned_images.down.sql
@@ -1,0 +1,2 @@
+-- Rollback: no-op since we can't restore deleted data
+-- This migration is meant for fresh deployments

--- a/db/migrations/003_clear_orphaned_images.up.sql
+++ b/db/migrations/003_clear_orphaned_images.up.sql
@@ -1,0 +1,7 @@
+-- Clear gallery items when setting up fresh volumes
+-- This prevents 404 errors for images that don't exist in new MinIO instance
+-- Only runs once when migration is first applied
+TRUNCATE TABLE gallery_items;
+
+-- Also clear site settings to avoid referencing non-existent images
+UPDATE site_settings SET hero_image_id = NULL, about_image_id = NULL WHERE id = 1;


### PR DESCRIPTION
Introduce migration scripts to clear orphaned images and reset site settings during fresh deployments, preventing 404 errors for non-existent images. These scripts run only once when the migration is first applied.