### PR TITLE
Update image path handling for new storage format

### DIFF
--- a/app/handlers.go
+++ b/app/handlers.go
@@ -170,7 +170,8 @@ func (s *Server) CreateGalleryItem(w http.ResponseWriter, r *http.Request) {
             return
         }
         
-        imagePath = fmt.Sprintf("/api/images/%s/%s", bucketName, filename)
+        // Store as bucket/filename format, not as /api/images/bucket/filename
+        imagePath = fmt.Sprintf("%s/%s", bucketName, filename)
     }
 
     var p GalleryItem

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -50,9 +50,15 @@ export interface LoginResponse {
 
 // Transform backend response to frontend format
 function transformImage(img: any): Image {
+  // Handle both old format (/api/images/gallery/...) and new format (gallery/...)
+  let url = img.image_path;
+  if (url && !url.startsWith('/api/images/')) {
+    url = `/api/images/${url}`;
+  }
+  
   return {
     ...img,
-    url: img.image_path,
+    url,
     category: img.info,
   };
 }


### PR DESCRIPTION
Update the image path handling in `CreateGalleryItem` to support a new storage format. Adjust `transformImage` to accommodate both the old and new formats for image URLs.